### PR TITLE
283 bone progress bug

### DIFF
--- a/MonstieWash/Assets/Prefabs/Interactable/StuckBone.prefab
+++ b/MonstieWash/Assets/Prefabs/Interactable/StuckBone.prefab
@@ -68,6 +68,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: StuckBone
       objectReference: {fileID: 0}
+    - target: {fileID: 4520279438470780351, guid: 243dad7d51190d044b8af32e561f6bf5, type: 3}
+      propertyPath: m_TagString
+      value: Pickable
+      objectReference: {fileID: 0}
     - target: {fileID: 9021122546331929797, guid: 243dad7d51190d044b8af32e561f6bf5, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -139,5 +143,25 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4520279438470780351, guid: 243dad7d51190d044b8af32e561f6bf5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9188176711408281038}
   m_SourcePrefab: {fileID: 100100000, guid: 243dad7d51190d044b8af32e561f6bf5, type: 3}
+--- !u!1 &3349159804403607175 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4520279438470780351, guid: 243dad7d51190d044b8af32e561f6bf5, type: 3}
+  m_PrefabInstance: {fileID: 1207484957358027576}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &9188176711408281038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3349159804403607175}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 634f91e6124631a42b8f398ce5771121, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/MonstieWash/Assets/Scenes/Game Scenes/Prototype 1/Mouth.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Prototype 1/Mouth.unity
@@ -304,6 +304,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6569485676934061755, guid: 070ad2168a3771e4b80e2709fbe626e2, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1160285249}
+    - targetCorrespondingSourceObject: {fileID: 6569485676934061755, guid: 070ad2168a3771e4b80e2709fbe626e2, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1618143253}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 070ad2168a3771e4b80e2709fbe626e2, type: 3}
 --- !u!4 &184414836 stripped
@@ -880,7 +883,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1618143253}
   m_Layer: 0
-  m_Name: ItemContainer
+  m_Name: Bones
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -894,7 +897,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1618143252}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -903,7 +906,7 @@ Transform:
   - {fileID: 219275432}
   - {fileID: 1902438811}
   - {fileID: 1936638644}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 184414836}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1902438810
 PrefabInstance:
@@ -1212,5 +1215,4 @@ SceneRoots:
   - {fileID: 483492758}
   - {fileID: 1077128141}
   - {fileID: 184414835}
-  - {fileID: 1618143253}
   - {fileID: 1278214514}

--- a/MonstieWash/Assets/Scenes/Game Scenes/Prototype 1/StartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Prototype 1/StartingScene.unity
@@ -265,7 +265,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -334859519322762873, guid: 7de047f7033100e49b73e17c1d959b99, type: 3}
       propertyPath: fontSize
-      value: 50
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: -334859519322762873, guid: 7de047f7033100e49b73e17c1d959b99, type: 3}
       propertyPath: clipboard

--- a/MonstieWash/Assets/Scenes/Game Scenes/SlimeLevel/SlimeFront.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/SlimeLevel/SlimeFront.unity
@@ -1321,7 +1321,7 @@ Transform:
   - {fileID: 1781492710}
   - {fileID: 837472313}
   - {fileID: 1601130954}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1505472009}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &863466000
 GameObject:
@@ -2016,6 +2016,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6569485676934061755, guid: 070ad2168a3771e4b80e2709fbe626e2, type: 3}
       insertIndex: -1
       addedObject: {fileID: 863466001}
+    - targetCorrespondingSourceObject: {fileID: 6569485676934061755, guid: 070ad2168a3771e4b80e2709fbe626e2, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 856972959}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 070ad2168a3771e4b80e2709fbe626e2, type: 3}
 --- !u!4 &1505472009 stripped
@@ -2956,7 +2959,6 @@ SceneRoots:
   - {fileID: 378574523}
   - {fileID: 41344705}
   - {fileID: 842176600}
-  - {fileID: 856972959}
   - {fileID: 870882003}
   - {fileID: 3799121171791714579}
   - {fileID: 690308038}

--- a/MonstieWash/Assets/Scripts/Erasing/Tasks/TaskTracker.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/Tasks/TaskTracker.cs
@@ -48,7 +48,7 @@ public class TaskTracker : MonoBehaviour
     /// <param name="taskName">A compound string made up of all parent objects in the hierarchy seperated by '#' eg. "Mimic#Front#Teeth#Dirt1". Used to identify each task and the associated locations.</param>
     private void InitialiseTasks(Transform taskContainer, string taskName)
     {
-        if (taskContainer.tag == "Erasable")
+        if (taskContainer.tag == "Erasable" || taskContainer.tag == "Pickable")
         {
             ITask iTask = taskContainer.GetComponent<ITask>();
             if (iTask != null)

--- a/MonstieWash/Assets/Scripts/Erasing/Tasks/TaskWrapper.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/Tasks/TaskWrapper.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+/// <summary>
+/// I needed an intermediary to pass data from Erasable struct to TaskTracker and in reverse. I couldn't find an alternative so this is a quick ugly fix. 
+/// </summary>
+public class TaskWrapper : MonoBehaviour, ITask
+{
+    private string m_taskName;
+    private float m_taskProgress;
+    private float m_newProgress;
+
+    public string TaskName 
+    { 
+        get { return m_taskName; } 
+        set { if (m_taskName == null) m_taskName = value; } 
+    }
+
+// Out of 100.
+    public float TaskProgress
+    {
+        get { return m_taskProgress; }
+        set
+        {
+            m_newProgress = value - m_taskProgress;
+            m_taskProgress = value;
+        }
+    }
+    public float NewProgress
+    {
+        get { return m_newProgress; }
+        set { NewProgress = value; }
+    }
+}

--- a/MonstieWash/Assets/Scripts/Erasing/Tasks/TaskWrapper.cs.meta
+++ b/MonstieWash/Assets/Scripts/Erasing/Tasks/TaskWrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 634f91e6124631a42b8f398ce5771121

--- a/MonstieWash/Assets/Scripts/Player/StuckItem.cs
+++ b/MonstieWash/Assets/Scripts/Player/StuckItem.cs
@@ -23,7 +23,7 @@ public class StuckItem : MonoBehaviour
     {
         get
         {
-            return Mathf.Lerp(startMaxRotation, endMaxRotation, (m_initialWiggleCount - wiggleCount + 1) / (float)m_initialWiggleCount);
+            return Mathf.Lerp(startMaxRotation, endMaxRotation, (m_initialWiggleCount - wiggleCount) / (float)m_initialWiggleCount);
         }
     }
     public Rigidbody2D Rb { get { return m_rb; } }
@@ -69,9 +69,9 @@ public class StuckItem : MonoBehaviour
     /// <returns>Whether this wiggle unstuck the item.</returns>
     public bool Wiggle()
     {
-        m_pickingTask.TaskProgress = 100f*(m_initialWiggleCount - wiggleCount + 1)/m_initialWiggleCount;
-        m_taskTracker.UpdateTaskTracker(m_pickingTask.TaskName, m_pickingTask.NewProgress);
         wiggleCount--;
+        m_pickingTask.TaskProgress = 100f*(m_initialWiggleCount - wiggleCount)/m_initialWiggleCount;
+        m_taskTracker.UpdateTaskTracker(m_pickingTask.TaskName, m_pickingTask.NewProgress);
 
         if (wiggleCount <= 0)
         {

--- a/MonstieWash/Assets/Scripts/Player/StuckItem.cs
+++ b/MonstieWash/Assets/Scripts/Player/StuckItem.cs
@@ -13,6 +13,8 @@ public class StuckItem : MonoBehaviour
     private Coroutine m_OOBCheckRoutine;
     private float m_initialRotation;
     private Transform m_initialParent;
+    private TaskTracker m_taskTracker;
+    private ITask m_pickingTask;
 
     public bool Stuck { get; private set; } = true;
     public float GrabDistance { get; private set; }
@@ -36,6 +38,8 @@ public class StuckItem : MonoBehaviour
         m_initialWiggleCount = wiggleCount;
         m_initialRotation = transform.rotation.eulerAngles.z;
         m_initialParent = transform.parent;
+        m_taskTracker = FindFirstObjectByType<TaskTracker>();
+        m_pickingTask = GetComponent<ITask>();
     }
 
     /// <summary>
@@ -65,6 +69,8 @@ public class StuckItem : MonoBehaviour
     /// <returns>Whether this wiggle unstuck the item.</returns>
     public bool Wiggle()
     {
+        m_pickingTask.TaskProgress = 100f*(m_initialWiggleCount - wiggleCount + 1)/m_initialWiggleCount;
+        m_taskTracker.UpdateTaskTracker(m_pickingTask.TaskName, m_pickingTask.NewProgress);
         wiggleCount--;
 
         if (wiggleCount <= 0)

--- a/MonstieWash/ProjectSettings/TagManager.asset
+++ b/MonstieWash/ProjectSettings/TagManager.asset
@@ -10,6 +10,7 @@ TagManager:
   - Right
   - Left
   - Back
+  - Pickable
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Small bugfix to track bone progress on clipboard.

Added tracking scripts for bone progress.
Added Pickable tag to identify bone picking tasks
Moved bone containers in game scenes to inside TaskContainer for task tracking

- [x]  I have run this branch locally
- [x]  I have performed a self-review of my code
- [x]  I have confirmed critical features still function