### PR TITLE
292 player bounds

### DIFF
--- a/MonstieWash/Assets/Prefabs/Interactable/PlayerHand.prefab
+++ b/MonstieWash/Assets/Prefabs/Interactable/PlayerHand.prefab
@@ -127,7 +127,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7847184bfdd0c9248a57ecaf61510a95, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cursorSpeed: 10
+  handSpeed: 20
+  extendBoundsX: 3
+  extendBoundsY: 3
+  showBounds: 1
 --- !u!114 &8624381380993330181
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/MonstieWash/Assets/Scripts/Player/PlayerHand.cs
+++ b/MonstieWash/Assets/Scripts/Player/PlayerHand.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 public class PlayerHand : MonoBehaviour
 {
     //Unity Inspector
-    [SerializeField][Range(1.0f, 50.0f)] private float cursorSpeed = 20f;
+    [SerializeField, Range(1.0f, 50.0f)] private float handSpeed = 20f;
+    [SerializeField, Range(0f, 5f)] private float extendBoundsX, extendBoundsY;
+    [SerializeField] private bool showBounds = false;
 
     //Private
     private Vector2 m_movement;
@@ -71,11 +73,11 @@ public class PlayerHand : MonoBehaviour
         {
             case InputManager.PlayerInputDevice.MKB:
                 {
-                    velocityModifer = cursorSpeed * k_mouseSpeedMultiplier;
+                    velocityModifer = handSpeed * k_mouseSpeedMultiplier;
                 } break;
             case InputManager.PlayerInputDevice.Controller:
                 {
-                    velocityModifer = cursorSpeed * Time.deltaTime;
+                    velocityModifer = handSpeed * Time.deltaTime;
                 } break;
         }
 
@@ -85,8 +87,8 @@ public class PlayerHand : MonoBehaviour
         var cameraHeightInWorldUnits = Camera.main.orthographicSize;
 
         //Keep within screen bounds
-        newPosition.x = Mathf.Clamp(newPosition.x, -cameraWidthInWorldUnits, cameraWidthInWorldUnits);
-        newPosition.y = Mathf.Clamp(newPosition.y, -cameraHeightInWorldUnits, cameraHeightInWorldUnits);
+        newPosition.x = Mathf.Clamp(newPosition.x, -cameraWidthInWorldUnits - extendBoundsX, cameraWidthInWorldUnits + extendBoundsX);
+        newPosition.y = Mathf.Clamp(newPosition.y, -cameraHeightInWorldUnits - extendBoundsY, cameraHeightInWorldUnits + extendBoundsY);
 
         return newPosition;
     }
@@ -101,5 +103,23 @@ public class PlayerHand : MonoBehaviour
         //Navigate
         TraversalObject navArrow = results[0].GetComponent<TraversalObject>();
         navArrow.OnClicked();
+    }
+
+    private void OnDrawGizmos()
+    {
+        if (!showBounds) return;
+
+        var cameraWidthInWorldUnits = Camera.main.orthographicSize * Camera.main.aspect;
+        var cameraHeightInWorldUnits = Camera.main.orthographicSize;
+
+        var topLeft = new Vector2(-cameraWidthInWorldUnits - extendBoundsX, cameraHeightInWorldUnits + extendBoundsY);
+        var topRight = new Vector2(cameraWidthInWorldUnits + extendBoundsX, cameraHeightInWorldUnits + extendBoundsY);
+        var bottomLeft = new Vector2(-cameraWidthInWorldUnits - extendBoundsX, -cameraHeightInWorldUnits - extendBoundsY);
+        var bottomRight = new Vector2(cameraWidthInWorldUnits + extendBoundsX, -cameraHeightInWorldUnits - extendBoundsY);
+
+        Debug.DrawLine(topLeft, topRight, Color.green);
+        Debug.DrawLine(topRight, bottomRight, Color.green);
+        Debug.DrawLine(bottomRight, bottomLeft, Color.green);
+        Debug.DrawLine(bottomLeft, topLeft, Color.green);
     }
 }


### PR DESCRIPTION
Added the ability to customize the player hand's bounds to allow them to move a bit outside the screen. Also contains a gizmo to see exactly where the bounds are.

📝
- [x]  I have run this branch locally
- [x]  I have performed a self-review of my code
- [x]  I have confirmed critical features still function
