### PR TITLE
274 area completion affects ai

### DIFF
--- a/MonstieWash/Assets/Particles/Sparkles/Sparkle_PS.prefab
+++ b/MonstieWash/Assets/Particles/Sparkles/Sparkle_PS.prefab
@@ -5209,8 +5209,8 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 2049462369
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_RenderMode: 0
   m_MeshDistribution: 0
@@ -10099,8 +10099,8 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 2049462369
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_RenderMode: 0
   m_MeshDistribution: 0
@@ -15343,8 +15343,8 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 2049462369
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_RenderMode: 0
   m_MeshDistribution: 0
@@ -20241,8 +20241,8 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 2049462369
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_RenderMode: 0
   m_MeshDistribution: 0

--- a/MonstieWash/Assets/Particles/SpongeVFX/Sponge_PS.prefab
+++ b/MonstieWash/Assets/Particles/SpongeVFX/Sponge_PS.prefab
@@ -4797,8 +4797,8 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 2049462369
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_RenderMode: 0
   m_MeshDistribution: 0

--- a/MonstieWash/Assets/Particles/WipeVFX/Wipe_PS (USE TRAIL INSTEAD).prefab
+++ b/MonstieWash/Assets/Particles/WipeVFX/Wipe_PS (USE TRAIL INSTEAD).prefab
@@ -4798,8 +4798,8 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 2049462369
+  m_SortingLayer: 7
   m_SortingOrder: 0
   m_RenderMode: 5
   m_MeshDistribution: 0

--- a/MonstieWash/Assets/Scenes/Game Scenes/Mimic/MimicStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Mimic/MimicStartingScene.unity
@@ -604,6 +604,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
+      propertyPath: pause
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: maxBetweenAttacks
       value: 12
       objectReference: {fileID: 0}
@@ -614,6 +618,10 @@ PrefabInstance:
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: moodData.Array.size
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
+      propertyPath: moodParticleOrigin.y
+      value: 2.2
       objectReference: {fileID: 0}
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: moodData.Array.data[0].mood

--- a/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Mimic/AngryMimic.asset
+++ b/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Mimic/AngryMimic.asset
@@ -23,3 +23,4 @@ MonoBehaviour:
   positiveReactionStrength: 0
   negativeChainReactions: []
   negativeReactionStrength: 0.1
+  sceneEffectOnMood: -4

--- a/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Mimic/HappyMimic.asset
+++ b/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Mimic/HappyMimic.asset
@@ -23,4 +23,4 @@ MonoBehaviour:
   positiveReactionStrength: 0
   negativeChainReactions: []
   negativeReactionStrength: 0
-  idleAnimation: {fileID: 0}
+  sceneEffectOnMood: 20

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
@@ -42,14 +42,30 @@ public class MonsterBrain : MonoBehaviour
     [HideInInspector] public HashSet<MoodType> Moods { get; private set; } = new();
     #endregion
 
+    #region References
+    private TaskTracker m_taskTracker;
+    #endregion
+
     private void Awake()
     {
+        m_taskTracker = FindFirstObjectByType<TaskTracker>();
+
         foreach (var data in moodData)
         {
             Moods.Add(data.mood);
         }
 
         m_attackTimer = UnityEngine.Random.Range(minBetweenAttacks, maxBetweenAttacks);
+    }
+
+    private void OnEnable()
+    {
+        m_taskTracker.OnSceneCompleted += UpdateMoodOnSceneComplete;
+    }
+
+    private void OnDisable()
+    {
+        m_taskTracker.OnSceneCompleted -= UpdateMoodOnSceneComplete;
     }
 
     private void Update()
@@ -338,5 +354,17 @@ public class MonsterBrain : MonoBehaviour
     {
         var data = moodData.Find(item => item.mood.MoodName == name);
         return data.value;
+    }
+
+    private void UpdateMoodOnSceneComplete()
+    {
+        for (int i = 0; i < moodData.Count; i++)
+        {
+            if (moodData[i].mood.SceneEffectOnMood == 0) continue;  // Skip if scene completion doesn't affect this mood
+
+            // Modify the mood by its sceneEffectOnMood value
+            UpdateMood(moodData[i].mood.SceneEffectOnMood, moodData[i].mood);
+            if (debug) print($"Mood {moodData[i].mood.name} was changed by {moodData[i].mood.SceneEffectOnMood} after scene completion");
+        }
     }
 }

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
@@ -114,8 +114,11 @@ public class MonsterController : MonoBehaviour
 
     public void AttackAnimationComplete()
     {
-        // Return to the animation that was playing previously
-        m_myAnimator.Play(m_interruptedAnimation.name);
-        m_interruptedAnimation = null;
+        if (m_interruptedAnimation != null) 
+        {
+            // Return to the animation that was playing previously
+            m_myAnimator.Play(m_interruptedAnimation.name);
+            m_interruptedAnimation = null;
+        }
     }
 }

--- a/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
@@ -30,6 +30,8 @@ public class MoodType : ScriptableObject
 
     [Tooltip("How strongly the negative effect is on other moods")][SerializeField] private float negativeReactionStrength; //How strong negative chain reactions will be.
 
+    [Tooltip("An optional particle system that portrays the moood to the player")][SerializeField] private ParticleSystem moodParticle; // Particle system associated with the mood (e.g. hearts for happiness)
+
     [Tooltip("How much the mood changes by when a scene is completed")][SerializeField] private float sceneEffectOnMood; // The value by which the mood changes when the OnSceneCompleted event is called.
 
     [HideInInspector] public string MoodName { get { return moodName; } }
@@ -43,6 +45,7 @@ public class MoodType : ScriptableObject
     [HideInInspector] public float PositiveReactionStrength { get { return positiveReactionStrength; } }
     [HideInInspector] public List<MoodType> NegativeChainReactions { get { return negativeChainReactions; } }
     [HideInInspector] public float NegativeReactionStrength { get { return negativeReactionStrength; } }
+    [HideInInspector] public ParticleSystem MoodParticle { get { return moodParticle; } }
     [HideInInspector] public float SceneEffectOnMood { get { return sceneEffectOnMood; } }
 
     #region Equality

--- a/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
@@ -30,6 +30,8 @@ public class MoodType : ScriptableObject
 
     [Tooltip("How strongly the negative effect is on other moods")][SerializeField] private float negativeReactionStrength; //How strong negative chain reactions will be.
 
+    [Tooltip("How much the mood changes by when a scene is completed")][SerializeField] private float sceneEffectOnMood; // The value by which the mood changes when the OnSceneCompleted event is called.
+
     [HideInInspector] public string MoodName { get { return moodName; } }
     [HideInInspector] public float MoodUpperLimit { get { return moodUpperLimit; } }
     [HideInInspector] public float MoodLowerLimit { get { return moodLowerLimit; } }
@@ -41,6 +43,7 @@ public class MoodType : ScriptableObject
     [HideInInspector] public float PositiveReactionStrength { get { return positiveReactionStrength; } }
     [HideInInspector] public List<MoodType> NegativeChainReactions { get { return negativeChainReactions; } }
     [HideInInspector] public float NegativeReactionStrength { get { return negativeReactionStrength; } }
+    [HideInInspector] public float SceneEffectOnMood { get { return sceneEffectOnMood; } }
 
     #region Equality
     public override bool Equals(object other)

--- a/MonstieWash/Assets/Scripts/Traversal/GameSceneManager.cs
+++ b/MonstieWash/Assets/Scripts/Traversal/GameSceneManager.cs
@@ -23,6 +23,8 @@ public class GameSceneManager : MonoBehaviour
     private List<string> m_activeScenes = new();
     private Level m_currentLevel;
 
+    [HideInInspector] public Scene CurrentScene { get { return m_currentScene; } }
+
     public List<string> AllLevelScenes { get; private set; } = new();
     public Level CurrentLevel;
 


### PR DESCRIPTION
Moods can now be modified by completing a scene (for example, completing a scene increases the happy mood and decreases the angry mood). Scenes that are adjusted in this way can additionally have an optional particle system that plays and informs the player of the change. 
**To test:** Adjust the MoodType scriptable objects, and change the parameters for "Mood Particle" and "Scene Effect On Mood". 
☑️ I have run this branch locally.
☑️ I have performed a self-review of my code.
☑️ I have confirmed critical features still function.