### PR TITLE
fix(polaroids): Polaroids are fixed again.

### DIFF
--- a/MonstieWash/Assets/Scripts/Traversal/GameSceneManager.cs
+++ b/MonstieWash/Assets/Scripts/Traversal/GameSceneManager.cs
@@ -25,7 +25,7 @@ public class GameSceneManager : MonoBehaviour
     [SerializeField] private GameScene deathScene;
     [SerializeField] private List<LevelScenes> allLevelScenes = new();
 
-    private Level m_currentLevel;
+    [SerializeField] private Level m_currentLevel;
     private Scene m_currentScene;
     private LevelScenes m_currentLevelScenes;
     private List<string> m_loadedScenes = new();
@@ -255,7 +255,7 @@ public class GameSceneManager : MonoBehaviour
 
         MoveToScene(loadingScene.SceneName);
 
-        m_currentLevel = Level.None;
+        //m_currentLevel = Level.None;
         SetSceneActive(m_currentLevelScenes.startingScene.SceneName, false);
         await LoadScene(scoreSummaryScene.SceneName);
 
@@ -358,6 +358,11 @@ public class GameSceneManager : MonoBehaviour
     {
         Debug.Log("Quitting...");
         Application.Quit();
+    }
+
+    public void ResetLevel()
+    {
+        m_currentLevel = Level.None;
     }
     #endregion
 }

--- a/MonstieWash/Assets/Scripts/Traversal/GameSceneManager.cs
+++ b/MonstieWash/Assets/Scripts/Traversal/GameSceneManager.cs
@@ -25,7 +25,7 @@ public class GameSceneManager : MonoBehaviour
     [SerializeField] private GameScene deathScene;
     [SerializeField] private List<LevelScenes> allLevelScenes = new();
 
-    [SerializeField] private Level m_currentLevel;
+    private Level m_currentLevel;
     private Scene m_currentScene;
     private LevelScenes m_currentLevelScenes;
     private List<string> m_loadedScenes = new();
@@ -255,7 +255,6 @@ public class GameSceneManager : MonoBehaviour
 
         MoveToScene(loadingScene.SceneName);
 
-        //m_currentLevel = Level.None;
         SetSceneActive(m_currentLevelScenes.startingScene.SceneName, false);
         await LoadScene(scoreSummaryScene.SceneName);
 
@@ -286,6 +285,7 @@ public class GameSceneManager : MonoBehaviour
     public async Task GoToBedroomScene(string target, bool targetIsUI)
     {
         var lastActiveScene = m_currentScene.name;
+        m_currentLevel = Level.None;
         MoveToScene(loadingScene.SceneName);
 
         if (!bedroomScenes.Exists(scene => scene.SceneName.Equals(lastActiveScene)))
@@ -358,11 +358,6 @@ public class GameSceneManager : MonoBehaviour
     {
         Debug.Log("Quitting...");
         Application.Quit();
-    }
-
-    public void ResetLevel()
-    {
-        m_currentLevel = Level.None;
     }
     #endregion
 }

--- a/MonstieWash/Assets/Scripts/UI/ScoreUIManager.cs
+++ b/MonstieWash/Assets/Scripts/UI/ScoreUIManager.cs
@@ -30,8 +30,8 @@ public class ScoreUIManager : MonoBehaviour
 		m_tracker = FindFirstObjectByType<TaskTracker>(FindObjectsInactive.Include);
         GameSceneManager gSM = FindFirstObjectByType<GameSceneManager>(FindObjectsInactive.Include);
 
-        if (m_sprites.Count >= (int)gSM.CurrentLevel)
-            m_polaroid.sprite = m_sprites[((int)gSM.CurrentLevel)];
+        if (m_sprites.Count >= (int)gSM.CurrentLevel - 1)
+            m_polaroid.sprite = m_sprites[((int)gSM.CurrentLevel - 1)];
         else
             Debug.LogError("Invalid level. No polaroid sprite available.");
 
@@ -39,6 +39,7 @@ public class ScoreUIManager : MonoBehaviour
         LoadOverallTasks();
 
         StartCoroutine(LineItemSetActive());
+        gSM.ResetLevel();
 	}
 
     private void OnEnable()

--- a/MonstieWash/Assets/Scripts/UI/ScoreUIManager.cs
+++ b/MonstieWash/Assets/Scripts/UI/ScoreUIManager.cs
@@ -39,7 +39,6 @@ public class ScoreUIManager : MonoBehaviour
         LoadOverallTasks();
 
         StartCoroutine(LineItemSetActive());
-        gSM.ResetLevel();
 	}
 
     private void OnEnable()


### PR DESCRIPTION
Moved the reset logic for current level enum to after the score screen is active.