### PR TITLE
570 removing upgrade and bedroom

### DIFF
--- a/MonstieWash/Assets/Scenes/Game Scenes/Bedroom/LevelSelectScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Bedroom/LevelSelectScene.unity
@@ -498,9 +498,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 996384be10af89946a0f302d7d2d5cbe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  action: 2
+  action: 3
   level: 0
-  targetScene: {fileID: 11400000, guid: f27043940161ff747aa1bb4da3c508ed, type: 2}
+  targetScene: {fileID: 11400000, guid: c9b85e23aaeb1d34fa4250e3d64a26f8, type: 2}
   targetIsUI: 0
   setMusic: 0
   music: 0

--- a/MonstieWash/Assets/Scenes/Game Scenes/Menus/GameStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Menus/GameStartingScene.unity
@@ -841,7 +841,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e49d73291b8dd75468eae6e3413d9855, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_menuCanvas: {fileID: 1446344132}
 --- !u!1001 &1836793582
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1159,12 +1158,12 @@ PrefabInstance:
       objectReference: {fileID: 1446344129}
     - target: {fileID: 8437575934485402516, guid: 7de047f7033100e49b73e17c1d959b99, type: 3}
       propertyPath: bedroomScenes.Array.size
-      value: 7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8437575934485402516, guid: 7de047f7033100e49b73e17c1d959b99, type: 3}
       propertyPath: 'bedroomScenes.Array.data[0]'
       value: 
-      objectReference: {fileID: 11400000, guid: 055eb2ef65e83b24ca61d262d2b5797a, type: 2}
+      objectReference: {fileID: 11400000, guid: c9b85e23aaeb1d34fa4250e3d64a26f8, type: 2}
     - target: {fileID: 8437575934485402516, guid: 7de047f7033100e49b73e17c1d959b99, type: 3}
       propertyPath: 'bedroomScenes.Array.data[1]'
       value: 

--- a/MonstieWash/Assets/Scenes/Game Scenes/Menus/ScoreSummary.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Menus/ScoreSummary.unity
@@ -572,7 +572,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   action: 2
   level: 0
-  targetScene: {fileID: 11400000, guid: 60381fa7d5c2d11488b6581a378ae663, type: 2}
+  targetScene: {fileID: 11400000, guid: c9b85e23aaeb1d34fa4250e3d64a26f8, type: 2}
   targetIsUI: 1
   setMusic: 1
   music: 2

--- a/MonstieWash/ProjectSettings/EditorBuildSettings.asset
+++ b/MonstieWash/ProjectSettings/EditorBuildSettings.asset
@@ -8,24 +8,6 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Game Scenes/Menus/GameStartingScene.unity
     guid: 69e618a8198683d438b74d000263a314
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/Alchemy.unity
-    guid: 949fc58099e033749a9bd7c022d4cce8
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/Bedroom.unity
-    guid: fe5f6bc22f505564b87488eeacd6919b
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/MonsterCompendium.unity
-    guid: f402e0dbd8966f94fadd334852c922de
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/Garden.unity
-    guid: a14e3e92d1a815a4991562d589a62b9f
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/Pigeon.unity
-    guid: 0928f67a7c08c7b4395f4d6c09e835d7
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/UpgradeTable.unity
-    guid: a36035a3571c8ce41a10ec493d2afceb
   - enabled: 1
     path: Assets/Scenes/Game Scenes/Bedroom/LevelSelectScene.unity
     guid: 901b889d8c9db7c47b3ebbf220ebdabf
@@ -35,18 +17,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Game Scenes/Menus/ScoreSummary.unity
     guid: c64edc70714cc75499eebb1e76b2a8d7
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Menus/DeathScreen.unity
-    guid: f9eb8cb70e7a3814083e62f071a3824c
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Bedroom/UpgradeScene.unity
-    guid: 64b3c50c44327de4c8e47839800c8ded
   - enabled: 1
     path: Assets/Scenes/Game Scenes/Mimic/MimicStartingScene.unity
     guid: aa33355a735657949b555275e662b643
-  - enabled: 0
-    path: Assets/Scenes/Game Scenes/Mimic/MimicOverview.unity
-    guid: 5f12d0f1c93aed941b27a58233e9fd0e
   - enabled: 1
     path: Assets/Scenes/Game Scenes/Mimic/MimicFront.unity
     guid: 8bbe0ba87cfeb654aae04488097a3808

--- a/MonstieWash/ProjectSettings/EditorBuildSettings.asset
+++ b/MonstieWash/ProjectSettings/EditorBuildSettings.asset
@@ -8,19 +8,19 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Game Scenes/Menus/GameStartingScene.unity
     guid: 69e618a8198683d438b74d000263a314
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Game Scenes/Bedroom/Alchemy.unity
     guid: 949fc58099e033749a9bd7c022d4cce8
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Game Scenes/Bedroom/Bedroom.unity
     guid: fe5f6bc22f505564b87488eeacd6919b
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Game Scenes/Bedroom/MonsterCompendium.unity
     guid: f402e0dbd8966f94fadd334852c922de
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Game Scenes/Bedroom/Garden.unity
     guid: a14e3e92d1a815a4991562d589a62b9f
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Game Scenes/Bedroom/Pigeon.unity
     guid: 0928f67a7c08c7b4395f4d6c09e835d7
   - enabled: 0
@@ -38,7 +38,7 @@ EditorBuildSettings:
   - enabled: 0
     path: Assets/Scenes/Game Scenes/Menus/DeathScreen.unity
     guid: f9eb8cb70e7a3814083e62f071a3824c
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Game Scenes/Bedroom/UpgradeScene.unity
     guid: 64b3c50c44327de4c8e47839800c8ded
   - enabled: 1


### PR DESCRIPTION
Removing of upgrade and bedroom scenes.

In build settings, deselected the compendium, upgrade, garden, pigeon and alchemy scenes
Game manager, made level select the only bedroom scene listed
Score summary, the continue button now leads to level select scene
Level select scene, the back button now quits the game but unsure what to do with the button