### PR TITLE
(feat): Expanded tutorial features and safety checks to prevent softl…

### DIFF
--- a/MonstieWash/Assets/Scenes/Game Scenes/Mimic/MimicMouth.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Mimic/MimicMouth.unity
@@ -330,6 +330,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: StuckBone (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.39
@@ -807,6 +811,10 @@ PrefabInstance:
     - target: {fileID: 3772658762332804611, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1440,6 +1448,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: StuckBone (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.4499999
@@ -1521,6 +1533,10 @@ PrefabInstance:
     - target: {fileID: 3349159804403607175, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_Name
       value: StuckBone (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalScale.x

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeBack.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeBack.unity
@@ -1687,6 +1687,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.9318349
@@ -2361,6 +2365,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalPosition.x
       value: 2.040397
@@ -2500,6 +2508,10 @@ PrefabInstance:
     - target: {fileID: 3349159804403607175, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_Name
       value: Item
+      objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalPosition.x

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeFront.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeFront.unity
@@ -1416,6 +1416,10 @@ PrefabInstance:
       propertyPath: m_score
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalPosition.x
       value: -2.03
@@ -2493,6 +2497,10 @@ PrefabInstance:
       propertyPath: m_score
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.9318349
@@ -3502,6 +3510,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
       propertyPath: m_score
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4738378391073371633, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}
+      propertyPath: m_taskType
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7855298997438079352, guid: 7132e4cdf39cf1a47af1df502a8907a2, type: 3}

--- a/MonstieWash/Assets/Scripts/Consumables/ChildConsumables/Treat.cs
+++ b/MonstieWash/Assets/Scripts/Consumables/ChildConsumables/Treat.cs
@@ -8,6 +8,8 @@ public class Treat : Consumable
 {
     [SerializeField] private List<MoodEffect> moods;
 
+    public static event Action UseTreat;
+
     [Serializable]
     public struct MoodEffect
     {
@@ -29,6 +31,7 @@ public class Treat : Consumable
             if (!brain.Moods.Contains(moods[i].target)) continue;
             brain.UpdateMood(moods[i].effect, moods[i].target);
             Debug.Log("Updating: " + moods[i].target + " by " + moods[i].effect);
+            UseTreat?.Invoke();
         }
 
         //Remove one of this consumable type from the manager.

--- a/MonstieWash/Assets/Scripts/Tasks/TaskData.cs
+++ b/MonstieWash/Assets/Scripts/Tasks/TaskData.cs
@@ -1,7 +1,10 @@
+using TMPro.EditorUtilities;
 using UnityEngine;
 
 public class TaskData : MonoBehaviour
 {
+    public enum TypeOfTask { Dirt, StuckItem };
+
 	[SerializeField] protected string m_id;
 
     [SerializeField] protected float m_progress;
@@ -13,12 +16,15 @@ public class TaskData : MonoBehaviour
 
 	[SerializeField] protected float m_score = 9.85f;
 
+    [SerializeField] protected TypeOfTask m_taskType;
+
 	public string Id { get => m_id; set => m_id = value; }
     public float Progress { get => m_progress; set => m_progress = value; }
     public bool Complete { get => m_complete; set => m_complete = value; }
     public float Threshold { get => m_threshold; set => m_threshold = value; }
     public Transform Container { get => m_container; }
 	public float Score { get => m_score; }
+    public TypeOfTask TaskType { get => m_taskType; }
 
 	private void OnAwake()
 	{

--- a/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -12,7 +12,7 @@ public class TutorialManager : MonoBehaviour
 
     private int m_tutorialStep = 0;       // Index for current tutorial prompt in the List
     private bool m_completed = false;     // Event flag for the current tutorial prompt
-    private enum CompletionEvent { ChangeScene, EraseStarted, OnMove, SwitchTool, UnstickItem };    // Enumerated list for designers of events to listen for
+    private enum CompletionEvent { ChangeScene, EraseStarted, OnMove, Scan, SwitchTool, ToggleUI, UnstickItem, UseTreat };    // Enumerated list for designers of events to listen for
     private enum CompletionType { Instant, Count, Time };
     // Enumerated list of ways the prompt can be completed:                                      
         // Instant - completes instantly once the event is received         (value = delay after event is received)
@@ -23,6 +23,7 @@ public class TutorialManager : MonoBehaviour
     private List<Eraser> m_erasers = new();
     private List<StuckItem> m_stuckItems = new();
     private ToolSwitcher m_toolSwitcher;
+    private TaskTracker m_taskTracker;
 
     [Serializable] 
     private struct TutorialPrompt
@@ -42,13 +43,17 @@ public class TutorialManager : MonoBehaviour
     {
         GameSceneManager.Instance.OnMonsterScenesLoaded += OnMonsterScenesLoaded;
         m_toolSwitcher = FindFirstObjectByType<ToolSwitcher>();
+        m_taskTracker = FindFirstObjectByType<TaskTracker>();
     }
 
     private void OnEnable()
     {
         GameSceneManager.Instance.OnSceneChanged += OnSceneChanged;
         InputManager.Instance.OnMove += OnMove;
+        InputManager.Instance.OnScan += OnScan;
         m_toolSwitcher.OnSwitchTool += OnSwitchTool;
+        InputManager.Instance.OnToggleUI += OnToggleUI;
+        Treat.UseTreat += UseTreat;
     }
 
     private void OnMonsterScenesLoaded()
@@ -65,9 +70,12 @@ public class TutorialManager : MonoBehaviour
     {
         GameSceneManager.Instance.OnSceneChanged -= OnSceneChanged;
         InputManager.Instance.OnMove -= OnMove;
+        InputManager.Instance.OnScan -= OnScan;
         foreach (var eraser in m_erasers) eraser.OnErasing_Started -= EraseStart;
         foreach (var stuckItem in m_stuckItems) stuckItem.OnItemUnstuck -= OnItemUnstuck;
         m_toolSwitcher.OnSwitchTool -= OnSwitchTool;
+        InputManager.Instance.OnToggleUI -= OnToggleUI;
+        Treat.UseTreat -= UseTreat;
     }
 
     private void Start()
@@ -76,6 +84,11 @@ public class TutorialManager : MonoBehaviour
         m_tutorialPrompts[m_tutorialStep].Prompt.SetActive(true);
         // Begin
         StartCoroutine(RunTutorial());
+    }
+
+    private void Update()
+    {
+        TaskSafetyCheck();  // Prevents the player from being softlocked
     }
 
     /// <summary>
@@ -202,7 +215,16 @@ public class TutorialManager : MonoBehaviour
         {
             RunCompletionTests(currentPrompt);
         }
-    }    
+    }
+
+    private void OnScan()
+    {
+        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
+        if (currentPrompt.CompleteEvent == CompletionEvent.Scan)
+        {
+            RunCompletionTests(currentPrompt);
+        }
+    }
 
     private void OnSceneChanged()
     {
@@ -229,6 +251,55 @@ public class TutorialManager : MonoBehaviour
         {
             RunCompletionTests(currentPrompt);
         }
+    }
+
+    private void OnToggleUI()
+    {
+        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
+        if (currentPrompt.CompleteEvent == CompletionEvent.ToggleUI)
+        {
+            RunCompletionTests(currentPrompt);
+        }
+    }
+
+    private void UseTreat()
+    {
+        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
+        if (currentPrompt.CompleteEvent == CompletionEvent.UseTreat)
+        {
+            RunCompletionTests(currentPrompt);
+        }
+    }
+    #endregion
+
+    #region Safety Checks
+    /// <summary>
+    /// Runs every frame and will skip a task if it is uncompletable by the player
+    /// </summary>
+    private void TaskSafetyCheck()
+    {
+        switch (m_tutorialPrompts[m_tutorialStep].CompleteEvent) {
+            case CompletionEvent.EraseStarted:
+                if (!DirtRemains()) m_completed = true; break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns TRUE if there is an uncompleted Dirt task in TaskTracker, otherwise returns FALSE.
+    /// </summary>
+    ///
+    private bool DirtRemains()
+    {
+        foreach (var task in m_taskTracker.TaskData)
+        {
+            if ((task.TaskType == TaskData.TypeOfTask.Dirt) && !task.Complete)
+            {
+                return true;
+            }
+        }
+        return false;
     }
     #endregion
 


### PR DESCRIPTION
Added tutorial event listeners for Scan, UI Toggle, Use Treat. 
Added safety check that can skip tasks if their completion criteria becomes impossible.
Other changes: Added an enum type "TaskType" to TaskData that is used to differentiate Dirt tasks from StuckItem tasks (used for the dirt cleaning safety check).

- [x]  I have run this branch locally
- [x]  I have performed a self-review of my code
- [x]  I have confirmed critical features still function