### PR TITLE
(feat): Added ability to check for tool type

### DIFF
--- a/MonstieWash/Assets/Prefabs/UI/Tutorial/TutorialManager.prefab
+++ b/MonstieWash/Assets/Prefabs/UI/Tutorial/TutorialManager.prefab
@@ -56,7 +56,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_tutorialPrompts:
   - prompt: {fileID: 8076963425140957593}
-    eventListen: 2
+    eventListen: 1
     promptCompletion: 2
     value: 0.5
   - prompt: {fileID: 3533757363977393950}

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
@@ -1763,6 +1763,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[2].value
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
       propertyPath: m_tutorialPrompts.Array.data[1].eventListen
       value: 3
       objectReference: {fileID: 0}

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
@@ -299,17 +299,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1640cfac3b933404b8fcf4cef7c94a5a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &682763575 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2570531277318799392, guid: 1b98c4b530574ff4496abcd0d30e53ef, type: 3}
-  m_PrefabInstance: {fileID: 2074756614}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &475764168
 GameObject:
   m_ObjectHideFlags: 0
@@ -385,6 +374,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 475764168}
   m_CullTransparentMesh: 1
+--- !u!114 &682763575 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2570531277318799392, guid: 1b98c4b530574ff4496abcd0d30e53ef, type: 3}
+  m_PrefabInstance: {fileID: 2074756614}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &825827905 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1023289354297892063, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
@@ -1761,6 +1761,34 @@ PrefabInstance:
     - target: {fileID: 2911753253606692221, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[1].eventListen
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[2].eventListen
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[3].eventListen
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[4].eventListen
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[6].eventListen
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[7].eventListen
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[8].eventListen
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4688208615737586938, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
       propertyPath: m_Name

--- a/MonstieWash/Assets/ScriptableObjects/Tools/Brush.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Tools/Brush.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   doNotErase: 0
   inputStrength: 66
   erasableLayers: 0000000002000000
-  toolType: 0
+  toolType: 1

--- a/MonstieWash/Assets/ScriptableObjects/Tools/Brush.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Tools/Brush.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   doNotErase: 0
   inputStrength: 66
   erasableLayers: 0000000002000000
+  toolType: 0

--- a/MonstieWash/Assets/ScriptableObjects/Tools/Sponge.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Tools/Sponge.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   doNotErase: 1
   inputStrength: 10
   erasableLayers: 0000000001000000
+  toolType: 2

--- a/MonstieWash/Assets/ScriptableObjects/Tools/Water Staff.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Tools/Water Staff.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   doNotErase: 0
   inputStrength: 100
   erasableLayers: 0000000001000000
+  toolType: 3

--- a/MonstieWash/Assets/Scripts/Erasing/Eraser.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/Eraser.cs
@@ -21,8 +21,8 @@ public class Eraser : MonoBehaviour
 
     public Tool Tool { get { return tool; } }
 
-    public event Action<bool> OnErasing_Started;    // True = Started erasing on a complete scene. | False = Started erasing on an incomplete scene. 
-    public event Action<bool> OnErasing_Ended;      // True = Stopped erasing on a complete scene. | False = Stopped erasing on an incomplete scene. 
+    public event Action<bool, Tool.ToolType> OnErasing_Started;    // True = Started erasing on a complete scene. | False = Started erasing on an incomplete scene. 
+    public event Action<bool, Tool.ToolType> OnErasing_Ended;      // True = Stopped erasing on a complete scene. | False = Stopped erasing on an incomplete scene. 
 
     /// <summary>
     /// A struct representing any erasable object (dirt, mould etc.) to keep track of all relevant values and apply changes.
@@ -140,8 +140,14 @@ public class Eraser : MonoBehaviour
             }
         }
 
-        if (!wasErasing && m_isErasing) OnErasing_Started?.Invoke(false);
-        if (wasErasing && !m_isErasing) OnErasing_Ended?.Invoke(false);
+        if (!wasErasing && m_isErasing)
+        {
+            OnErasing_Started?.Invoke(false, tool.TypeOfTool);
+        }
+        if (wasErasing && !m_isErasing)
+        {
+            OnErasing_Ended?.Invoke(false, tool.TypeOfTool);
+        }
     }
 
     public void UseToolClean()
@@ -150,7 +156,7 @@ public class Eraser : MonoBehaviour
 
         if (!m_isErasingClean && (m_distFromCentre < maxSparkleDist && m_taskTracker.IsThisSceneComplete()))
         {
-            OnErasing_Started?.Invoke(true);
+            OnErasing_Started?.Invoke(true, tool.TypeOfTool);
             m_isErasingClean = true;
         }
         if (m_isErasingClean && m_distFromCentre > maxSparkleDist)
@@ -166,7 +172,7 @@ public class Eraser : MonoBehaviour
     {
         if (m_isErasing)
         {
-            OnErasing_Ended?.Invoke(false);
+            OnErasing_Ended?.Invoke(false, tool.TypeOfTool);
             m_isErasing = false;
         }
     }
@@ -175,7 +181,7 @@ public class Eraser : MonoBehaviour
     {
         if (m_isErasingClean)
         {
-            OnErasing_Ended?.Invoke(true);
+            OnErasing_Ended?.Invoke(true, tool.TypeOfTool);
             m_isErasingClean = false;
         }
     }

--- a/MonstieWash/Assets/Scripts/Erasing/Eraser.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/Eraser.cs
@@ -21,8 +21,8 @@ public class Eraser : MonoBehaviour
 
     public Tool Tool { get { return tool; } }
 
-    public event Action<bool, Tool.ToolType> OnErasing_Started;    // True = Started erasing on a complete scene. | False = Started erasing on an incomplete scene. 
-    public event Action<bool, Tool.ToolType> OnErasing_Ended;      // True = Stopped erasing on a complete scene. | False = Stopped erasing on an incomplete scene. 
+    public event Action<bool, Tool> OnErasing_Started;    // True = Started erasing on a complete scene. | False = Started erasing on an incomplete scene. 
+    public event Action<bool, Tool> OnErasing_Ended;      // True = Stopped erasing on a complete scene. | False = Stopped erasing on an incomplete scene. 
 
     /// <summary>
     /// A struct representing any erasable object (dirt, mould etc.) to keep track of all relevant values and apply changes.
@@ -142,11 +142,11 @@ public class Eraser : MonoBehaviour
 
         if (!wasErasing && m_isErasing)
         {
-            OnErasing_Started?.Invoke(false, tool.TypeOfTool);
+            OnErasing_Started?.Invoke(false, tool);
         }
         if (wasErasing && !m_isErasing)
         {
-            OnErasing_Ended?.Invoke(false, tool.TypeOfTool);
+            OnErasing_Ended?.Invoke(false, tool);
         }
     }
 
@@ -156,7 +156,7 @@ public class Eraser : MonoBehaviour
 
         if (!m_isErasingClean && (m_distFromCentre < maxSparkleDist && m_taskTracker.IsThisSceneComplete()))
         {
-            OnErasing_Started?.Invoke(true, tool.TypeOfTool);
+            OnErasing_Started?.Invoke(true, tool);
             m_isErasingClean = true;
         }
         if (m_isErasingClean && m_distFromCentre > maxSparkleDist)
@@ -172,7 +172,7 @@ public class Eraser : MonoBehaviour
     {
         if (m_isErasing)
         {
-            OnErasing_Ended?.Invoke(false, tool.TypeOfTool);
+            OnErasing_Ended?.Invoke(false, tool);
             m_isErasing = false;
         }
     }
@@ -181,7 +181,7 @@ public class Eraser : MonoBehaviour
     {
         if (m_isErasingClean)
         {
-            OnErasing_Ended?.Invoke(true, tool.TypeOfTool);
+            OnErasing_Ended?.Invoke(true, tool);
             m_isErasingClean = false;
         }
     }

--- a/MonstieWash/Assets/Scripts/Erasing/Tool.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/Tool.cs
@@ -6,18 +6,22 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "Tool", menuName = "ScriptableObjects/Tool")]
 public class Tool : ScriptableObject
 {
+    public enum ToolType { Brush, None, Sponge, WaterWand };
+
     public string toolName = "";
     public Sprite mask;
     [Range(1, 10)] public int size = 1;
     [SerializeField] private bool doNotErase = false;
     [SerializeField][Range(1f, 100f)] private float inputStrength = 100f;
     [SerializeField] private List<ErasableLayerer.ErasableLayer> erasableLayers = new();
+    [SerializeField] private ToolType toolType = ToolType.None;
 
     public byte[] MaskPixels { get; private set; }
     public bool DoNotErase { get { return doNotErase; } }
     public float InputStrength { get { return inputStrength; } set { inputStrength = Mathf.Clamp(value, 1f, 100f); } }
     public float Strength { get; private set; }
     public List<ErasableLayerer.ErasableLayer> ErasableLayers { get { return erasableLayers; } }
+    public ToolType TypeOfTool { get { return toolType; } }
 
     /// <summary>
     /// Initalize the tool, setting up all required values and variables. (Used in place of an Awake)

--- a/MonstieWash/Assets/Scripts/Erasing/Tool.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/Tool.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "Tool", menuName = "ScriptableObjects/Tool")]
 public class Tool : ScriptableObject
 {
-    public enum ToolType { Brush, None, Sponge, WaterWand };
+    public enum ToolType { None, Brush, Sponge, WaterWand };
 
     public string toolName = "";
     public Sprite mask;

--- a/MonstieWash/Assets/Scripts/Erasing/ToolFX.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/ToolFX.cs
@@ -43,7 +43,7 @@ public class ToolFX : MonoBehaviour
         m_completeParticles = Instantiate(particlesOnComplete, m_drawPosTransform);
     }
 
-    private void Eraser_OnErasing(bool completeScene, Tool.ToolType toolType)
+    private void Eraser_OnErasing(bool completeScene, Tool tool)
     {
         if (!completeScene)
         {
@@ -56,7 +56,7 @@ public class ToolFX : MonoBehaviour
 
     }
 
-    private void Eraser_OnErasing_Ended(bool completeScene, Tool.ToolType toolType)
+    private void Eraser_OnErasing_Ended(bool completeScene, Tool tool)
     {
         if (!completeScene)
         {

--- a/MonstieWash/Assets/Scripts/Erasing/ToolFX.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/ToolFX.cs
@@ -43,7 +43,7 @@ public class ToolFX : MonoBehaviour
         m_completeParticles = Instantiate(particlesOnComplete, m_drawPosTransform);
     }
 
-    private void Eraser_OnErasing(bool completeScene)
+    private void Eraser_OnErasing(bool completeScene, Tool.ToolType toolType)
     {
         if (!completeScene)
         {
@@ -56,7 +56,7 @@ public class ToolFX : MonoBehaviour
 
     }
 
-    private void Eraser_OnErasing_Ended(bool completeScene)
+    private void Eraser_OnErasing_Ended(bool completeScene, Tool.ToolType toolType)
     {
         if (!completeScene)
         {

--- a/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -87,11 +87,6 @@ public class TutorialManager : MonoBehaviour
         StartCoroutine(RunTutorial());
     }
 
-    private void Update()
-    {
-        TaskSafetyCheck();  // Prevents the player from being softlocked
-    }
-
     /// <summary>
     /// Runs the tutorial.
     /// </summary>
@@ -215,9 +210,9 @@ public class TutorialManager : MonoBehaviour
         EventTriggered(CompletionEvent.OnMove);
     }
 
-    private void EraseStart(bool value, Tool.ToolType toolType)
+    private void EraseStart(bool value, Tool tool)
     {
-        switch (toolType)
+        switch (tool.TypeOfTool)
         {
             case Tool.ToolType.Brush:
                 Debug.Log("Use brush");
@@ -234,6 +229,8 @@ public class TutorialManager : MonoBehaviour
             default:
                 break;  //ToolType.None
         }
+
+        TaskSafetyCheck(tool); // Prevents the player from being softlocked
     }
 
     private void OnScan()
@@ -271,25 +268,21 @@ public class TutorialManager : MonoBehaviour
     /// <summary>
     /// Runs every frame and will skip a task if it is uncompletable by the player
     /// </summary>
-    private void TaskSafetyCheck()
+    private void TaskSafetyCheck(Tool tool)
     {
-        // == BROKEN - SEARCH FOR SPECIFIC DIRT TYPES BASED ON WHICH TOOL TYPE IS REQUIRED TO BE USED!! ==
-
-        /* 
-
         switch (m_tutorialPrompts[m_tutorialStep].CompleteEvent) {
             case CompletionEvent.UseBrush:
-                if (!DirtRemains()) m_completed = true; break;
+                {
+                    if (!DirtRemainsForTool(tool)) m_completed = true;
+
+                } break;
             default:
                 break;
         }
-
-        */
-
     }
 
     /// <summary>
-    /// Returns TRUE if there is an uncompleted Dirt task in TaskTracker, otherwise returns FALSE.
+    /// Returns TRUE if there is an incomplete Dirt task in TaskTracker, otherwise returns FALSE.
     /// </summary>
     ///
     private bool DirtRemains()
@@ -299,6 +292,25 @@ public class TutorialManager : MonoBehaviour
             if ((task.TaskType == TaskType.Dirt) && !task.Complete)
             {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns TRUE if there is an incomplete Dirt task in TaskTracker that can be erased by the given tool, otherwise returns FALSE.
+    /// </summary>
+    /// <param name="tool">The tool to check for remaining erasables.</param>
+    private bool DirtRemainsForTool(Tool tool)
+    {
+        foreach (var task in m_taskTracker.TaskData)
+        {
+            if ((task.TaskType == TaskType.Dirt) && !task.Complete)
+            {
+                var dirt = task.Container.gameObject;
+                var dirtLayerInToolLayer = tool.ErasableLayers.Contains(dirt.GetComponent<ErasableLayerer>().Layer);
+
+                if (dirtLayerInToolLayer) return true;
             }
         }
         return false;

--- a/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -12,7 +13,7 @@ public class TutorialManager : MonoBehaviour
 
     private int m_tutorialStep = 0;       // Index for current tutorial prompt in the List
     private bool m_completed = false;     // Event flag for the current tutorial prompt
-    private enum CompletionEvent { ChangeScene, EraseStarted, OnMove, Scan, SwitchTool, ToggleUI, UnstickItem, UseTreat };    // Enumerated list for designers of events to listen for
+    private enum CompletionEvent { ChangeScene, OnMove, Scan, SwitchTool, ToggleUI, UnstickItem, UseBrush, UseSponge, UseWaterWand, UseTreat };    // Enumerated list for designers of events to listen for
     private enum CompletionType { Instant, Count, Time };
     // Enumerated list of ways the prompt can be completed:                                      
         // Instant - completes instantly once the event is received         (value = delay after event is received)
@@ -199,76 +200,70 @@ public class TutorialManager : MonoBehaviour
     #endregion
 
     #region Event Listeners
-    private void OnMove(Vector2 movement)
+
+    private void EventTriggered(CompletionEvent eventType)
     {
         var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.OnMove)
+        if (currentPrompt.CompleteEvent == eventType)
         {
             RunCompletionTests(currentPrompt);
         }
     }
 
-    private void EraseStart(bool value)
+    private void OnMove(Vector2 movement)
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.EraseStarted)
+        EventTriggered(CompletionEvent.OnMove);
+    }
+
+    private void EraseStart(bool value, Tool.ToolType toolType)
+    {
+        switch (toolType)
         {
-            RunCompletionTests(currentPrompt);
+            case Tool.ToolType.Brush:
+                Debug.Log("Use brush");
+                EventTriggered(CompletionEvent.UseBrush);
+                break;
+            case Tool.ToolType.Sponge:
+                Debug.Log("Use sponge");
+                EventTriggered(CompletionEvent.UseSponge);
+                break;
+            case Tool.ToolType.WaterWand:
+                Debug.Log("Use water wand");
+                EventTriggered(CompletionEvent.UseWaterWand);
+                break;
+            default:
+                break;  //ToolType.None
         }
     }
 
     private void OnScan()
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.Scan)
-        {
-            RunCompletionTests(currentPrompt);
-        }
+        EventTriggered(CompletionEvent.Scan);
     }
 
     private void OnSceneChanged()
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.ChangeScene)
-        {
-            RunCompletionTests(currentPrompt);
-        }
+        EventTriggered(CompletionEvent.ChangeScene);
     }
 
     private void OnSwitchTool()
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.SwitchTool)
-        {
-            RunCompletionTests(currentPrompt);
-        }
+        EventTriggered(CompletionEvent.SwitchTool);
     }
 
     private void OnItemUnstuck()
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.UnstickItem)
-        {
-            RunCompletionTests(currentPrompt);
-        }
+        EventTriggered(CompletionEvent.UnstickItem);
     }
 
     private void OnToggleUI()
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.ToggleUI)
-        {
-            RunCompletionTests(currentPrompt);
-        }
+        EventTriggered(CompletionEvent.ToggleUI);
     }
 
     private void UseTreat()
     {
-        var currentPrompt = m_tutorialPrompts[m_tutorialStep];
-        if (currentPrompt.CompleteEvent == CompletionEvent.UseTreat)
-        {
-            RunCompletionTests(currentPrompt);
-        }
+        EventTriggered(CompletionEvent.UseTreat);
     }
     #endregion
 
@@ -278,12 +273,19 @@ public class TutorialManager : MonoBehaviour
     /// </summary>
     private void TaskSafetyCheck()
     {
+        // == BROKEN - SEARCH FOR SPECIFIC DIRT TYPES BASED ON WHICH TOOL TYPE IS REQUIRED TO BE USED!! ==
+
+        /* 
+
         switch (m_tutorialPrompts[m_tutorialStep].CompleteEvent) {
-            case CompletionEvent.EraseStarted:
+            case CompletionEvent.UseBrush:
                 if (!DirtRemains()) m_completed = true; break;
             default:
                 break;
         }
+
+        */
+
     }
 
     /// <summary>

--- a/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -215,15 +215,12 @@ public class TutorialManager : MonoBehaviour
         switch (tool.TypeOfTool)
         {
             case Tool.ToolType.Brush:
-                Debug.Log("Use brush");
                 EventTriggered(CompletionEvent.UseBrush);
                 break;
             case Tool.ToolType.Sponge:
-                Debug.Log("Use sponge");
                 EventTriggered(CompletionEvent.UseSponge);
                 break;
             case Tool.ToolType.WaterWand:
-                Debug.Log("Use water wand");
                 EventTriggered(CompletionEvent.UseWaterWand);
                 break;
             default:


### PR DESCRIPTION
TutorialManager can now listen for an enumerated ToolType value when using a cleaning tool: Brush, None, Sponge, or WaterWand. Designers can select which type of tool to listen for specifically when preparing the tutorial.
I also did some cleaning up of the TutorialManager class, specifically with how it listens for events, to remove some duplicated code. 

- [x]  I have run this branch locally
- [x]  I have performed a self-review of my code
- [x]  I have confirmed critical features still function