### PR TITLE
(feat): Added manager for scripted events, and connected to tutorial

### DIFF
--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
@@ -285,9 +285,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7942194253567946431, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1369750622}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
+--- !u!4 &165354734 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7942194253567946431, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
+  m_PrefabInstance: {fileID: 165354733}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &165354736 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8005725319209823100, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
@@ -647,6 +655,52 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4233595091761023778, guid: 321865daa1dc2744f912d46b59fb0c32, type: 3}
   m_PrefabInstance: {fileID: 1307418497}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1369750621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1369750622}
+  - component: {fileID: 1369750623}
+  m_Layer: 0
+  m_Name: ScriptedEventsManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1369750622
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369750621}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 165354734}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1369750623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369750621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c589b97dffa77374184a3fbcf4d50318, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debugMode: 0
+  monsterAngryMood: {fileID: 11400000, guid: 34568d0770a2eb24fa70568ba9044e08, type: 2}
 --- !u!1001 &1475573996
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1793,6 +1847,18 @@ PrefabInstance:
     - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
       propertyPath: m_tutorialPrompts.Array.data[8].eventListen
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[0].scriptedEvent
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[2].scriptedEvent
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4470456935035511546, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
+      propertyPath: m_tutorialPrompts.Array.data[4].scriptedEvent
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4688208615737586938, guid: 601d67c9f3f20954486675e29cc75b69, type: 3}
       propertyPath: m_Name

--- a/MonstieWash/Assets/Scripts/ScriptedEvents.meta
+++ b/MonstieWash/Assets/Scripts/ScriptedEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60222495a80a91d469ed5eab774ee897
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MonstieWash/Assets/Scripts/ScriptedEvents/ScriptedEventManager.cs
+++ b/MonstieWash/Assets/Scripts/ScriptedEvents/ScriptedEventManager.cs
@@ -41,16 +41,8 @@ public class ScriptedEventsManager : MonoBehaviour
             // create and add perms for new subscriber
             foreach (ScriptedEventType eventType in Enum.GetValues(typeof(ScriptedEventType)))
             {
-                bool found = false;
-                foreach (var permission in permissions)
-                {
-                    if (permission == eventType)
-                    {
-                        m_subscribers[subscriber].Add(eventType, true);
-                        found = true;
-                    }
-                }
-                if (!found) m_subscribers[subscriber].Add(eventType, false);
+                if (permissions.Contains(eventType)) m_subscribers[subscriber].Add(eventType, true);
+                else m_subscribers[subscriber].Add(eventType, false);
             }
         }
     }
@@ -70,34 +62,34 @@ public class ScriptedEventsManager : MonoBehaviour
 
     public void RunScriptedEvent(GameObject caller, ScriptedEventType type)
     {
-        switch (type)
+        if (m_subscribers.ContainsKey(caller))  // if caller is subscribed
         {
-            case ScriptedEventType.SetAngry:
-                SetAngry(caller);
-                break;
-            default:
-                break;
+            switch (type)
+            {
+                case ScriptedEventType.SetAngry:
+                    if (m_subscribers[caller][ScriptedEventType.SetAngry])  // if caller has permission to execute this scripted event
+                    {
+                        SetAngry(caller);
+                    }
+                    else // caller doesn't have permission
+                    {
+                        if (debugMode) Debug.LogWarning($"{caller.name} tried to call scripted event SetAngry but is missing permissions to do so!");
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        else // caller isn't subscribed
+        {
+            if (debugMode) Debug.LogWarning($"{caller.name} tried to call a scripted event but isn't subscribed!");
         }
     }
 
-    public void SetAngry(GameObject caller)
+    private void SetAngry(GameObject caller)
     {
-        if (m_subscribers.ContainsKey(caller))  // if caller is subscribed
-        {
-            if (m_subscribers[caller][ScriptedEventType.SetAngry])  // if caller has permission to execute this scripted event
-            {
-                // currently sets the monster to its maximum anger
-                float maxAnger = monsterAngryMood.MoodUpperLimit;
-                m_monsterBrain.UpdateMood(maxAnger, monsterAngryMood);
-            }
-            else
-            {
-                if (debugMode) Debug.LogWarning($"{caller.name} tried to call scripted event SetAngry but is missing permissions to do so!");
-            }
-        }
-        else
-        {
-            if (debugMode) Debug.LogWarning($"{caller.name} tried to call scripted event SetAngry but hasn't subscribed to Scripted Events!");
-        }
+        // currently sets the monster to its maximum anger
+        float maxAnger = monsterAngryMood.MoodUpperLimit;
+        m_monsterBrain.UpdateMood(maxAnger, monsterAngryMood);
     }
 }

--- a/MonstieWash/Assets/Scripts/ScriptedEvents/ScriptedEventManager.cs
+++ b/MonstieWash/Assets/Scripts/ScriptedEvents/ScriptedEventManager.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class ScriptedEventsManager : MonoBehaviour
+{
+    public static ScriptedEventsManager Instance;
+
+    private MonsterBrain m_monsterBrain;
+
+    [SerializeField] bool debugMode;    // whether to print debug messages
+
+    [SerializeField] MoodType monsterAngryMood; // annoying to have to do this, but we don't have a better way to detect a monster's angry mood at the moment
+
+    public enum ScriptedEventType { None, SetAngry }; // Which scripted events exist
+    private Dictionary<ScriptedEventType, bool> m_eventPermission = new Dictionary<ScriptedEventType, bool>(); // Used to reference whether an event is available to a subscriber
+    private Dictionary<GameObject, Dictionary<ScriptedEventType, bool>> m_subscribers = new Dictionary<GameObject, Dictionary<ScriptedEventType, bool>>(); // Used to reference subscribers and permissions
+
+    private void Awake()
+    {
+        //Ensure there's only one
+        if (Instance == null) Instance = this;
+        else Destroy(this);
+
+        m_monsterBrain = FindFirstObjectByType<MonsterBrain>();
+    }
+
+    public void Subscribe(GameObject subscriber, params ScriptedEventType[] permissions)
+    {
+        if (!m_subscribers.ContainsKey(subscriber))     // subscriber can only be subscribed once
+        {
+            // create and add new subscriber
+            Dictionary<ScriptedEventType, bool> myPerms = new Dictionary<ScriptedEventType, bool>();
+            m_subscribers.Add(subscriber, myPerms);
+
+            // create and add perms for new subscriber
+            foreach (ScriptedEventType eventType in Enum.GetValues(typeof(ScriptedEventType)))
+            {
+                bool found = false;
+                foreach (var permission in permissions)
+                {
+                    if (permission == eventType)
+                    {
+                        m_subscribers[subscriber].Add(eventType, true);
+                        found = true;
+                    }
+                }
+                if (!found) m_subscribers[subscriber].Add(eventType, false);
+            }
+        }
+    }
+
+    public void Unsubscribe(GameObject subscriber)
+    {
+        if (m_subscribers.ContainsKey(subscriber)) m_subscribers.Remove(subscriber);
+    }
+
+    public void ModifyPermission(GameObject subscriber, ScriptedEventType type, bool newVal)
+    {
+        if (m_subscribers.ContainsKey(subscriber))
+        {
+            m_subscribers[subscriber][type] = newVal;
+        }
+    }
+
+    public void RunScriptedEvent(GameObject caller, ScriptedEventType type)
+    {
+        switch (type)
+        {
+            case ScriptedEventType.SetAngry:
+                SetAngry(caller);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void SetAngry(GameObject caller)
+    {
+        if (m_subscribers.ContainsKey(caller))  // if caller is subscribed
+        {
+            if (m_subscribers[caller][ScriptedEventType.SetAngry])  // if caller has permission to execute this scripted event
+            {
+                // currently sets the monster to its maximum anger
+                float maxAnger = monsterAngryMood.MoodUpperLimit;
+                m_monsterBrain.UpdateMood(maxAnger, monsterAngryMood);
+            }
+            else
+            {
+                if (debugMode) Debug.LogWarning($"{caller.name} tried to call scripted event SetAngry but is missing permissions to do so!");
+            }
+        }
+        else
+        {
+            if (debugMode) Debug.LogWarning($"{caller.name} tried to call scripted event SetAngry but hasn't subscribed to Scripted Events!");
+        }
+    }
+}

--- a/MonstieWash/Assets/Scripts/ScriptedEvents/ScriptedEventManager.cs.meta
+++ b/MonstieWash/Assets/Scripts/ScriptedEvents/ScriptedEventManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c589b97dffa77374184a3fbcf4d50318

--- a/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -7,6 +7,7 @@ using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Events;
 
+
 public class TutorialManager : MonoBehaviour
 {
     [Tooltip("List of tutorial prompts in sequential order")][SerializeField] private List<TutorialPrompt> m_tutorialPrompts;     // List of prompts to iterate through
@@ -26,6 +27,9 @@ public class TutorialManager : MonoBehaviour
     private ToolSwitcher m_toolSwitcher;
     private TaskTracker m_taskTracker;
 
+    // scripted events - include scripted event enumtypes to be used here (tutoriial should probably have all types)
+    private ScriptedEventsManager m_scriptedEventsManager;
+
     [Serializable] 
     private struct TutorialPrompt
     {
@@ -33,11 +37,13 @@ public class TutorialManager : MonoBehaviour
         [Tooltip("The event to listen for")][SerializeField] private CompletionEvent eventListen;                    
         [Tooltip("The method to detect for completion")][SerializeField] private CompletionType promptCompletion;
         [Tooltip("The value to pair with the completion detection method")][SerializeField] private float value;
+        [Tooltip("The scripted event to occur")][SerializeField] private ScriptedEventsManager.ScriptedEventType scriptedEvent;
 
         public GameObject Prompt { get { return prompt; } }
         public CompletionEvent CompleteEvent { get { return eventListen; } }
         public CompletionType CompleteType { get { return promptCompletion; } }
         public float Value { get { return value; } }
+        public ScriptedEventsManager.ScriptedEventType ScriptedEventType { get { return scriptedEvent; } }
     }
 
     private void Awake()
@@ -45,6 +51,11 @@ public class TutorialManager : MonoBehaviour
         GameSceneManager.Instance.OnMonsterScenesLoaded += OnMonsterScenesLoaded;
         m_toolSwitcher = FindFirstObjectByType<ToolSwitcher>();
         m_taskTracker = FindFirstObjectByType<TaskTracker>();
+        m_scriptedEventsManager = FindFirstObjectByType<ScriptedEventsManager>();
+
+        // subscribe to all Scripted Events Manager events
+        m_scriptedEventsManager.Subscribe(gameObject,
+            ScriptedEventsManager.ScriptedEventType.SetAngry);
     }
 
     private void OnEnable()
@@ -94,16 +105,25 @@ public class TutorialManager : MonoBehaviour
     {
         foreach (var prompt in m_tutorialPrompts)
         {
+            // run the scripted event for the new prompt if there is one
+            var currentPrompt = m_tutorialPrompts[m_tutorialStep];
+            if (currentPrompt.ScriptedEventType != ScriptedEventsManager.ScriptedEventType.None) m_scriptedEventsManager.RunScriptedEvent(gameObject, currentPrompt.ScriptedEventType);
+
+            // wait for the prompt to be completed
             yield return new WaitUntil(() => m_completed);
+
+            // reset complete flag and hide old prompt
             m_completed = false;
             m_tutorialPrompts[m_tutorialStep].Prompt.SetActive(false);
 
+            // dont exceed bounds of prompt list
             if (m_tutorialStep <  m_tutorialPrompts.Count - 1)
             {
+                // show new prompt
                 m_tutorialStep++;
-                var currentPrompt = m_tutorialPrompts[m_tutorialStep];
+                currentPrompt = m_tutorialPrompts[m_tutorialStep];
                 currentPrompt.Prompt.SetActive(true);
-
+                // run safety checks
                 if (currentPrompt.CompleteEvent == CompletionEvent.UnstickItem) SetStuckItemTrackedValue();
             }
         }
@@ -196,6 +216,10 @@ public class TutorialManager : MonoBehaviour
 
     #region Event Listeners
 
+    /// <summary>
+    /// Runs a completion check if the triggered event type matches the current prompt event listener. 
+    /// </summary>
+    /// <param name="eventType">The event to evaluate.</param>
     private void EventTriggered(CompletionEvent eventType)
     {
         var currentPrompt = m_tutorialPrompts[m_tutorialStep];
@@ -259,6 +283,21 @@ public class TutorialManager : MonoBehaviour
     {
         EventTriggered(CompletionEvent.UseTreat);
     }
+    #endregion
+
+    #region Scripted Events
+
+    private void RunScriptedEvent(ScriptedEventsManager.ScriptedEventType type) { 
+        switch (type)
+        {
+            case ScriptedEventsManager.ScriptedEventType.SetAngry:
+                m_scriptedEventsManager.SetAngry(gameObject);
+                break;
+            default:
+                break;
+        }
+    }
+
     #endregion
 
     #region Safety Checks

--- a/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/MonstieWash/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -291,7 +291,7 @@ public class TutorialManager : MonoBehaviour
         switch (type)
         {
             case ScriptedEventsManager.ScriptedEventType.SetAngry:
-                m_scriptedEventsManager.SetAngry(gameObject);
+                m_scriptedEventsManager.RunScriptedEvent(gameObject, ScriptedEventsManager.ScriptedEventType.SetAngry);
                 break;
             default:
                 break;


### PR DESCRIPTION
Added a new static manager script (ScriptedEventsManager) and allowed TutorialManager to access it. The general idea is that ScriptedEventsManager will manage "scripted events" i.e. events happening at specific intervals, via allowing other scripts/classes to subscribe to it with various permissions depending on which scripted events they should create. Kind of like a reverse event system (many classes with access to scripted events)

- [x]  I have run this branch locally
- [x]  I have performed a self-review of my code
- [x]  I have confirmed critical features still function