### PR TITLE
612 bug fixes

### DIFF
--- a/MonstieWash/Assets/Particles/Moods/Angry/AngryFX.prefab
+++ b/MonstieWash/Assets/Particles/Moods/Angry/AngryFX.prefab
@@ -116,8 +116,8 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 1
-      minScalar: 3
+      scalar: 0.5
+      minScalar: 1
       maxCurve:
         serializedVersion: 2
         m_Curve:

--- a/MonstieWash/Assets/Particles/Moods/Happy/HappyFX.prefab
+++ b/MonstieWash/Assets/Particles/Moods/Happy/HappyFX.prefab
@@ -116,8 +116,8 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 1
-      minScalar: 3
+      scalar: 0.5
+      minScalar: 1
       maxCurve:
         serializedVersion: 2
         m_Curve:

--- a/MonstieWash/Assets/Particles/Moods/Sad/SadFX.prefab
+++ b/MonstieWash/Assets/Particles/Moods/Sad/SadFX.prefab
@@ -116,8 +116,8 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 1
-      minScalar: 3
+      scalar: 0.5
+      minScalar: 1
       maxCurve:
         serializedVersion: 2
         m_Curve:

--- a/MonstieWash/Assets/Prefabs/MoodAffectors/Mood FX.prefab
+++ b/MonstieWash/Assets/Prefabs/MoodAffectors/Mood FX.prefab
@@ -9,7 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4620877448687494269}
-  m_Layer: 12
+  - component: {fileID: 98984872855425359}
+  m_Layer: 0
   m_Name: Mood FX
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -34,6 +35,25 @@ Transform:
   - {fileID: 5046835958086704119}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &98984872855425359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8701429289123836779}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bb46fea5681adc499850c2e1b5625fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moodToSystem:
+  - mood: {fileID: 11400000, guid: c21217ce1f7317e46922f477e55c6ab2, type: 2}
+    particleSystem: {fileID: 3386892717480709554}
+  - mood: {fileID: 11400000, guid: 34568d0770a2eb24fa70568ba9044e08, type: 2}
+    particleSystem: {fileID: 779581136623032217}
+  - mood: {fileID: 11400000, guid: 9960f9a81733f884797d9bf5e07ff6fc, type: 2}
+    particleSystem: {fileID: 8921980780792005341}
 --- !u!1001 &1610818768220020783
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -52,7 +72,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5788024587013094360, guid: 1af71c9aa5c75c74e942d8fb72a6be23, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.7660604
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5788024587013094360, guid: 1af71c9aa5c75c74e942d8fb72a6be23, type: 3}
       propertyPath: m_LocalPosition.z
@@ -104,6 +124,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5788024587013094360, guid: 1af71c9aa5c75c74e942d8fb72a6be23, type: 3}
   m_PrefabInstance: {fileID: 1610818768220020783}
   m_PrefabAsset: {fileID: 0}
+--- !u!198 &8921980780792005341 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 7893676676032307954, guid: 1af71c9aa5c75c74e942d8fb72a6be23, type: 3}
+  m_PrefabInstance: {fileID: 1610818768220020783}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4795016277145595712
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -122,7 +147,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5788024587013094360, guid: 676ed2be7ebb8234fb116945ca6f813c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.7660604
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5788024587013094360, guid: 676ed2be7ebb8234fb116945ca6f813c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -170,6 +195,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5788024587013094360, guid: 676ed2be7ebb8234fb116945ca6f813c, type: 3}
   m_PrefabInstance: {fileID: 4795016277145595712}
   m_PrefabAsset: {fileID: 0}
+--- !u!198 &3386892717480709554 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 7893676676032307954, guid: 676ed2be7ebb8234fb116945ca6f813c, type: 3}
+  m_PrefabInstance: {fileID: 4795016277145595712}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7447363840812250475
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -188,7 +218,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5788024587013094360, guid: e89a2cd1afd1f664cb9a655a2e6147aa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.7660604
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5788024587013094360, guid: e89a2cd1afd1f664cb9a655a2e6147aa, type: 3}
       propertyPath: m_LocalPosition.z
@@ -227,6 +257,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e89a2cd1afd1f664cb9a655a2e6147aa, type: 3}
+--- !u!198 &779581136623032217 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 7893676676032307954, guid: e89a2cd1afd1f664cb9a655a2e6147aa, type: 3}
+  m_PrefabInstance: {fileID: 7447363840812250475}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &3965815598890847923 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5788024587013094360, guid: e89a2cd1afd1f664cb9a655a2e6147aa, type: 3}

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeBack.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeBack.unity
@@ -1296,7 +1296,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4620877448687494269, guid: 067bd41c3bb0def4484096612ecba263, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.3194187
+      value: 1.4466417
       objectReference: {fileID: 0}
     - target: {fileID: 4620877448687494269, guid: 067bd41c3bb0def4484096612ecba263, type: 3}
       propertyPath: m_LocalPosition.z

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeFront.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeFront.unity
@@ -3512,7 +3512,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4620877448687494269, guid: 067bd41c3bb0def4484096612ecba263, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.3194187
+      value: 1.4466417
       objectReference: {fileID: 0}
     - target: {fileID: 4620877448687494269, guid: 067bd41c3bb0def4484096612ecba263, type: 3}
       propertyPath: m_LocalPosition.z

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
@@ -129,7 +129,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: debug
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: debugUi

--- a/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
+++ b/MonstieWash/Assets/Scenes/Game Scenes/Slime/SlimeStartingScene.unity
@@ -129,8 +129,12 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: debug
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
+      propertyPath: debugUi
+      value: 
+      objectReference: {fileID: 2119829317}
     - target: {fileID: 1661805892012121062, guid: 8224d585e82748442ae79dfd4e22549a, type: 3}
       propertyPath: numOfDirt
       value: 3
@@ -1739,6 +1743,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8232238471059561256, guid: 1b98c4b530574ff4496abcd0d30e53ef, type: 3}
   m_PrefabInstance: {fileID: 2074756614}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2119829317 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1801075961970723756, guid: 1b98c4b530574ff4496abcd0d30e53ef, type: 3}
+  m_PrefabInstance: {fileID: 2074756614}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7241775246093986046
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeAngry.asset
+++ b/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeAngry.asset
@@ -16,13 +16,7 @@ MonoBehaviour:
   moodUpperLimit: 30
   moodLowerLimit: 0
   moodStartingPoint: 0
-  moodNaturalChange: 0
+  moodNaturalChange: 1
   moodRestingPoint: 0
-  chaosMultiplier: 0
-  positiveChainReactions: []
-  positiveReactionStrength: 0
-  negativeChainReactions:
-  - {fileID: 11400000, guid: c21217ce1f7317e46922f477e55c6ab2, type: 2}
-  negativeReactionStrength: 2
-  moodParticle: {fileID: 0}
+  attackThreshold: 20
   sceneEffectOnMood: -30

--- a/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeHappy.asset
+++ b/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeHappy.asset
@@ -16,15 +16,7 @@ MonoBehaviour:
   moodUpperLimit: 30
   moodLowerLimit: 0
   moodStartingPoint: 0
-  moodNaturalChange: 0
+  moodNaturalChange: 1
   moodRestingPoint: 0
-  chaosMultiplier: 0
-  positiveChainReactions: []
-  positiveReactionStrength: 0
-  negativeChainReactions:
-  - {fileID: 11400000, guid: 34568d0770a2eb24fa70568ba9044e08, type: 2}
-  - {fileID: 11400000, guid: 9960f9a81733f884797d9bf5e07ff6fc, type: 2}
-  - {fileID: 11400000, guid: 7c085ae8b7e03fe4f9f1412031a4109e, type: 2}
-  negativeReactionStrength: 0.5
-  moodParticle: {fileID: 0}
+  attackThreshold: 99
   sceneEffectOnMood: 30

--- a/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeIdle.asset
+++ b/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeIdle.asset
@@ -13,15 +13,10 @@ MonoBehaviour:
   m_Name: slimeIdle
   m_EditorClassIdentifier: 
   moodName: slimeIdle
-  moodUpperLimit: 15
-  moodLowerLimit: 0
-  moodStartingPoint: 10
-  moodNaturalChange: 1
-  moodRestingPoint: 10
-  chaosMultiplier: 0
-  positiveChainReactions: []
-  positiveReactionStrength: 0
-  negativeChainReactions: []
-  negativeReactionStrength: 0
-  moodParticle: {fileID: 0}
+  moodUpperLimit: 5
+  moodLowerLimit: 5
+  moodStartingPoint: 5
+  moodNaturalChange: 0
+  moodRestingPoint: 5
+  attackThreshold: 99
   sceneEffectOnMood: 0

--- a/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeSad.asset
+++ b/MonstieWash/Assets/ScriptableObjects/MonsterMoods/Slime/slimeSad.asset
@@ -16,13 +16,7 @@ MonoBehaviour:
   moodUpperLimit: 20
   moodLowerLimit: 0
   moodStartingPoint: 20
-  moodNaturalChange: 0
+  moodNaturalChange: 1
   moodRestingPoint: 0
-  chaosMultiplier: 0
-  positiveChainReactions: []
-  positiveReactionStrength: 0.33
-  negativeChainReactions:
-  - {fileID: 11400000, guid: c21217ce1f7317e46922f477e55c6ab2, type: 2}
-  negativeReactionStrength: 1
-  moodParticle: {fileID: 0}
+  attackThreshold: 99
   sceneEffectOnMood: -20

--- a/MonstieWash/Assets/ScriptableObjects/Treats/BoneConsume.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Treats/BoneConsume.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   diminishingReturns: 0
   moods:
   - target: {fileID: 11400000, guid: c21217ce1f7317e46922f477e55c6ab2, type: 2}
-    effect: 25
+    effect: 30
   - target: {fileID: 11400000, guid: ccbfee3ea46a08a40bc6f491debfcaba, type: 2}
-    effect: 25
+    effect: 30

--- a/MonstieWash/Assets/ScriptableObjects/Treats/CupcakeConsume.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Treats/CupcakeConsume.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   diminishingReturns: 0
   moods:
   - target: {fileID: 11400000, guid: 9960f9a81733f884797d9bf5e07ff6fc, type: 2}
-    effect: -25
+    effect: -30
   - target: {fileID: 11400000, guid: 78750ed21c19e0e4ebc7d1f00b732044, type: 2}
-    effect: -25
+    effect: -30

--- a/MonstieWash/Assets/ScriptableObjects/Treats/PotionConsume.asset
+++ b/MonstieWash/Assets/ScriptableObjects/Treats/PotionConsume.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   diminishingReturns: 0
   moods:
   - target: {fileID: 11400000, guid: 34568d0770a2eb24fa70568ba9044e08, type: 2}
-    effect: -25
+    effect: -30
   - target: {fileID: 11400000, guid: 78750ed21c19e0e4ebc7d1f00b732044, type: 2}
-    effect: -25
+    effect: -30

--- a/MonstieWash/Assets/Scripts/Effects/MoodFXManager.cs
+++ b/MonstieWash/Assets/Scripts/Effects/MoodFXManager.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MoodFXManager : MonoBehaviour
+{
+    [System.Serializable]
+    private struct MoodParticleSystem
+    {
+        public MoodType mood;
+        public ParticleSystem particleSystem;
+    }
+
+    [SerializeField] private List<MoodParticleSystem> moodToSystem = new();
+
+    private Dictionary<MoodType, ParticleSystem> m_moodParticleSystems = new();
+
+    public Dictionary<MoodType, ParticleSystem> MoodParticleSystems { get { return m_moodParticleSystems; } }
+
+    private void Awake()
+    {
+        foreach (var mps in moodToSystem)
+        {
+            m_moodParticleSystems.Add(mps.mood, mps.particleSystem);
+        }
+    }
+}

--- a/MonstieWash/Assets/Scripts/Effects/MoodFXManager.cs.meta
+++ b/MonstieWash/Assets/Scripts/Effects/MoodFXManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9bb46fea5681adc499850c2e1b5625fa

--- a/MonstieWash/Assets/Scripts/Erasing/ToolFX.cs
+++ b/MonstieWash/Assets/Scripts/Erasing/ToolFX.cs
@@ -27,6 +27,12 @@ public class ToolFX : MonoBehaviour
         m_eraser.OnErasing_Ended += Eraser_OnErasing_Ended;
         InputManager.Instance.OnActivate += Inputs_OnActivate;
         InputManager.Instance.OnActivate_Ended += Inputs_OnActivate_Ended;
+        GameSceneManager.Instance.OnSceneSwitch += OnSceneSwitch;
+    }
+
+    private void OnSceneSwitch()
+    {
+        m_myParticles.Clear();
     }
 
     private void OnDisable()

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
@@ -119,7 +119,7 @@ public class MonsterBrain : MonoBehaviour
             //Assign new value to active mood.
             moodData[i].value = currentValue;
 
-            //if (debug) print("Active Mood: " + moodData[i].mood.MoodName + " naturally changed to " + currentValue);
+            if (debug) print("Active Mood: " + moodData[i].mood.MoodName + " naturally changed to " + currentValue);
         }
     }
 

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
@@ -388,39 +388,8 @@ public class MonsterBrain : MonoBehaviour
 
             // Modify the mood by its sceneEffectOnMood value
             UpdateMood(moodData[i].mood.SceneEffectOnMood, moodData[i].mood);
-            // Play the mood's particle system
-            StartCoroutine(PlayMoodParticles(moodData[i].mood));
             // Debug
             if (debug) print($"Mood {moodData[i].mood.name} was changed by {moodData[i].mood.SceneEffectOnMood} after scene completion");
-        }
-    }
-
-    /// <summary>
-    /// Plays the particle system associated with the mood.
-    /// </summary>
-    /// <param name="mood"> Which mood's particle system to use</param>
-    /// <param name="time"> How long to play for (default 1.5 seconds)</param>
-    IEnumerator PlayMoodParticles(MoodType mood, float time = 1.5f)
-    {
-        if (mood.MoodParticle != null)
-        {
-            /*
-            * NOTE: Creating and destroying particles sytems might not be the most performative, but consider that these particles need to exist across multiple
-            * scenes (each angle of the monster). Consider asking designers how frequently particles will play to determine if a better solution is required. 
-            */
-
-            var tempParticles = Instantiate(mood.MoodParticle, moodParticleOrigin, Quaternion.identity); // The mood's ParticleSystem
-            SceneManager.MoveGameObjectToScene(tempParticles.gameObject, GameSceneManager.Instance.CurrentScene);
-            tempParticles.Play();
-
-            yield return new WaitForSeconds(time);
-
-            tempParticles.Stop();
-            Destroy(tempParticles);
-        }
-        else
-        {
-            if (debug) print($"Moodtype {mood.name} doesn't have a particle system attached");
         }
     }
 

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterBrain.cs
@@ -12,7 +12,6 @@ public class MonsterBrain : MonoBehaviour
     protected class MoodData
     {
         public MoodType mood;
-        [Tooltip("Monster won't attack unless mood value is equal or higher than its attack threshold")]public float attackThreshold;
         public float value;
     }
 
@@ -120,7 +119,7 @@ public class MonsterBrain : MonoBehaviour
             //Assign new value to active mood.
             moodData[i].value = currentValue;
 
-            if (debug) print("Active Mood: " + moodData[i].mood.MoodName + " naturally changed to " + currentValue);
+            //if (debug) print("Active Mood: " + moodData[i].mood.MoodName + " naturally changed to " + currentValue);
         }
     }
 
@@ -282,13 +281,11 @@ public class MonsterBrain : MonoBehaviour
         if (m_lastAttackTime < m_attackTimer) return;
 
         // Check to see if an attack should be performed based on mood values.
-        for (int i = 0; i < moodData.Count; i++)
+        var highestMoodData = moodData.Find(m => m.mood == HighestMood);
+        if (highestMoodData == null || highestMoodData.value < highestMoodData.mood.AttackThreshold) // If the value of a mood is below its attack threshold, an attack is not made.
         {
-            if (moodData[i].value < moodData[i].attackThreshold)    // If the value of a mood is below its attack threshold, an attack is not made.
-            {
-                m_lastAttackTime = 0f;
-                return;
-            }
+            m_lastAttackTime = 0f;
+            return;
         }
 
         // Attack is legal, perform the attack.

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
@@ -80,7 +80,7 @@ public class MonsterController : MonoBehaviour
         if (currentMood == m_recentHighestMood) return;
 
         // If currently performing an attack, should NOT update
-        if (m_interruptAnimation != null) return;
+        //if (m_interruptAnimation != null) return;
 
         // Update the recent highest mood, then play the exit animation followed by the new animation
         m_recentHighestMood = currentMood;

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
@@ -80,9 +80,6 @@ public class MonsterController : MonoBehaviour
         // If mood hasn't changed from last frame, don't bother updating
         if (currentMood == m_recentHighestMood) return;
 
-        // If currently performing an attack, should NOT update
-        //if (m_interruptAnimation != null) return;
-
         // Update the recent highest mood, then play the exit animation followed by the new animation
         m_recentHighestMood = currentMood;
         if (debug) Debug.Log($"Current highest mood was changed to {m_recentHighestMood}");

--- a/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MonsterController.cs
@@ -22,6 +22,7 @@ public class MonsterController : MonoBehaviour
     private SoundPlayer m_soundPlayer;
 
     public event Action OnInterruptComplete;
+    public event Action OnAttackBegin;
     public event Action OnAttackEnd;
 
     [Serializable]
@@ -131,6 +132,7 @@ public class MonsterController : MonoBehaviour
 
         // Play the attack animation
         m_myAnimator.Play(attack.name);
+        OnAttackBegin();
     }
 
     public void AttackStarted()

--- a/MonstieWash/Assets/Scripts/MonsterAi/MoodArea.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MoodArea.cs
@@ -28,9 +28,6 @@ public class MoodArea : MonoBehaviour
     [Header("FadingSprites")]
     [Tooltip("Fading sprite scripts that will fade in when this area is touched.")] [SerializeField] private List<FadingSprite> spritesToActivate;
 
-    [Header("Particle Effect")]
-    [SerializeField] private ParticleSystem moodParticleSystem;
-
     //Internal states
     private float currentCooldown;
     private float currentEffectiveness; //Current effectiveness of area.
@@ -38,6 +35,7 @@ public class MoodArea : MonoBehaviour
     private bool m_isPetting;
     private BoxCollider2D m_collider;
     private bool m_isOnCooldown { get { return currentCooldown != 0f; } }
+    private MoodFXManager m_moodFXManager;
 
     public event Action OnPetStarted;
     public event Action OnPetEnded;
@@ -64,6 +62,11 @@ public class MoodArea : MonoBehaviour
         {
             m_OriginalMat = spriteToOutline.material;
         }
+    }
+
+    private void Start()
+    {
+        m_moodFXManager = FindFirstObjectByType<MoodFXManager>();
     }
 
     private void OnEnable()
@@ -113,6 +116,8 @@ public class MoodArea : MonoBehaviour
         {
             m_monsterBrain.UpdateMood(moodEffect.reactionStrength * (currentEffectiveness/100f), moodEffect.mood);
             if (debug) print($"Reaction Strength  {moodEffect.reactionStrength}  at effectivness of {currentEffectiveness} for the mood {moodEffect.mood.MoodName}");
+
+            m_moodFXManager.MoodParticleSystems[moodEffect.mood].Play();
         }
 
         //Apply diminishing effect if toggled on.
@@ -127,7 +132,6 @@ public class MoodArea : MonoBehaviour
             m_isPetting = true;
         }
 
-        if (moodParticleSystem != null) moodParticleSystem.Play();
     }
 
     /// <summary>

--- a/MonstieWash/Assets/Scripts/MonsterAi/MoodArea.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MoodArea.cs
@@ -117,7 +117,7 @@ public class MoodArea : MonoBehaviour
             m_monsterBrain.UpdateMood(moodEffect.reactionStrength * (currentEffectiveness/100f), moodEffect.mood);
             if (debug) print($"Reaction Strength  {moodEffect.reactionStrength}  at effectivness of {currentEffectiveness} for the mood {moodEffect.mood.MoodName}");
 
-            m_moodFXManager.MoodParticleSystems[moodEffect.mood].Play();
+            m_moodFXManager.MoodParticleSystems[moodEffect.mood]?.Play();
         }
 
         //Apply diminishing effect if toggled on.

--- a/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
@@ -32,8 +32,6 @@ public class MoodType : ScriptableObject
 
     [Tooltip("How strongly the negative effect is on other moods")]/*[SerializeField]*/ private float negativeReactionStrength; //How strong negative chain reactions will be.
 
-    [Tooltip("An optional particle system that portrays the moood to the player")][SerializeField] private ParticleSystem moodParticle; // Particle system associated with the mood (e.g. hearts for happiness)
-
     [Tooltip("How much the mood changes by when a scene is completed")][SerializeField] private float sceneEffectOnMood; // The value by which the mood changes when the OnSceneCompleted event is called.
 
     [HideInInspector] public string MoodName { get { return moodName; } }
@@ -48,7 +46,6 @@ public class MoodType : ScriptableObject
     [HideInInspector] public float PositiveReactionStrength { get { return positiveReactionStrength; } }
     [HideInInspector] public List<MoodType> NegativeChainReactions { get { return negativeChainReactions; } }
     [HideInInspector] public float NegativeReactionStrength { get { return negativeReactionStrength; } }
-    [HideInInspector] public ParticleSystem MoodParticle { get { return moodParticle; } }
     [HideInInspector] public float SceneEffectOnMood { get { return sceneEffectOnMood; } }
 
     #region Equality

--- a/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
+++ b/MonstieWash/Assets/Scripts/MonsterAi/MoodType.cs
@@ -20,15 +20,17 @@ public class MoodType : ScriptableObject
 
     [Tooltip("The resting point that the mood will naturally change towards by above number")][SerializeField] private float moodRestingPoint; //The point at which the mood will remain stationary.
 
-    [Tooltip("Introduces random changes to the mood, recomended number 0-10 and can use decimals")][SerializeField] private float chaosMultiplier; //Random interference of mood level to create less certainty.
+    [Tooltip("Monster won't attack unless mood value is equal or higher than its attack threshold")][SerializeField] private float attackThreshold;
 
-    [Tooltip("Drag other moodtypes here that the brain has that will be positively affected by this mood")][SerializeField] private List<MoodType> positiveChainReactions; //This mood will push other moods of this type towards their upper limit based on how close this mood itself is to its upper limit.
+    [Tooltip("Introduces random changes to the mood, recomended number 0-10 and can use decimals")]/*[SerializeField]*/ private float chaosMultiplier; //Random interference of mood level to create less certainty.
 
-    [Tooltip("How strongly the positive effect is on other moods")][SerializeField] private float positiveReactionStrength; //How strong positive chain reactions will be.
+    [Tooltip("Drag other moodtypes here that the brain has that will be positively affected by this mood")]/*[SerializeField]*/ private List<MoodType> positiveChainReactions; //This mood will push other moods of this type towards their upper limit based on how close this mood itself is to its upper limit.
 
-    [Tooltip("Drag other moodtypes here that the brain has that will be negatively affected by this mood")][SerializeField] private List<MoodType> negativeChainReactions; //This mood will push other moods of this type towards their lower limit based on how close this mood itself is to its lower limit.
+    [Tooltip("How strongly the positive effect is on other moods")]/*[SerializeField]*/ private float positiveReactionStrength; //How strong positive chain reactions will be.
 
-    [Tooltip("How strongly the negative effect is on other moods")][SerializeField] private float negativeReactionStrength; //How strong negative chain reactions will be.
+    [Tooltip("Drag other moodtypes here that the brain has that will be negatively affected by this mood")]/*[SerializeField]*/ private List<MoodType> negativeChainReactions; //This mood will push other moods of this type towards their lower limit based on how close this mood itself is to its lower limit.
+
+    [Tooltip("How strongly the negative effect is on other moods")]/*[SerializeField]*/ private float negativeReactionStrength; //How strong negative chain reactions will be.
 
     [Tooltip("An optional particle system that portrays the moood to the player")][SerializeField] private ParticleSystem moodParticle; // Particle system associated with the mood (e.g. hearts for happiness)
 
@@ -40,6 +42,7 @@ public class MoodType : ScriptableObject
     [HideInInspector] public float MoodStartingPoint { get { return moodStartingPoint; } }
     [HideInInspector] public float MoodNaturalChange { get { return moodNaturalChange; } }
     [HideInInspector] public float MoodRestingPoint { get { return moodRestingPoint; } }
+    [HideInInspector] public float AttackThreshold {  get { return attackThreshold; } }
     [HideInInspector] public float ChaosMultiplier { get { return chaosMultiplier; } }
     [HideInInspector] public List<MoodType> PositiveChainReactions { get { return positiveChainReactions; } }
     [HideInInspector] public float PositiveReactionStrength { get { return positiveReactionStrength; } }

--- a/MonstieWash/Assets/Scripts/Traversal/TraversalObject.cs
+++ b/MonstieWash/Assets/Scripts/Traversal/TraversalObject.cs
@@ -4,6 +4,7 @@ public class TraversalObject : MonoBehaviour, INavigator
 {
     [SerializeField] private GameScene targetScene;
     [SerializeField] private bool targetIsUI;
+    [SerializeField] private Color disabledColour = new Color(0.5f, 0f, 0f);
 
     private string m_targetScene;
     private bool m_traversalEnabled = true;
@@ -30,7 +31,7 @@ public class TraversalObject : MonoBehaviour, INavigator
     private void MonsterController_OnAttackStart()
     {
         m_traversalEnabled = false;
-        m_spriteRenderer.color = new Color(0.5f, 0f, 0f);
+        m_spriteRenderer.color = disabledColour;
     }
 
     public void OnClicked()

--- a/MonstieWash/Assets/Scripts/Traversal/TraversalObject.cs
+++ b/MonstieWash/Assets/Scripts/Traversal/TraversalObject.cs
@@ -6,15 +6,35 @@ public class TraversalObject : MonoBehaviour, INavigator
     [SerializeField] private bool targetIsUI;
 
     private string m_targetScene;
+    private bool m_traversalEnabled = true;
+    private SpriteRenderer m_spriteRenderer;
 
     public void Awake()
     {
         if (targetScene == null) Debug.LogError($"Target scene not assigned for {name}!");
         else m_targetScene = targetScene.SceneName;
+
+        var monsterController = FindFirstObjectByType<MonsterController>();
+        monsterController.OnAttackBegin += MonsterController_OnAttackStart;
+        monsterController.OnAttackEnd += MonsterController_OnAttackEnd;
+
+        m_spriteRenderer = GetComponent<SpriteRenderer>();
+    }
+
+    private void MonsterController_OnAttackEnd()
+    {
+        m_traversalEnabled = true;
+        m_spriteRenderer.color = Color.white;
+    }
+
+    private void MonsterController_OnAttackStart()
+    {
+        m_traversalEnabled = false;
+        m_spriteRenderer.color = new Color(0.5f, 0f, 0f);
     }
 
     public void OnClicked()
     {
-        GameSceneManager.Instance.MoveToScene(m_targetScene, targetIsUI);
+        if (m_traversalEnabled) GameSceneManager.Instance.MoveToScene(m_targetScene, targetIsUI);
     }
 }


### PR DESCRIPTION
Lots of little fixes included in this one, feel free to look at it per-commit as it might be easier to see which changes correspond to which fixes that way. The full set of changes are:

- minor mood rework to make moods more predictable; moods also decay to idle slowly. Also hid some unused mood properties.
- centralized the mood particle systems into the MoodFX prefab within the monster for easy universal access.
- made bubbles despawn when the scene is changed.
- disabled navigation while the monster is attacking.

Let me know if you've got any questions!