### PR TITLE
(fix): Tutorial only runs once Task Introduction is hidden

### DIFF
--- a/MonstieWash/Assets/Scripts/UI/UIManager.cs
+++ b/MonstieWash/Assets/Scripts/UI/UIManager.cs
@@ -28,6 +28,8 @@ public class UIManager : MonoBehaviour
     private ProgressBarUI[] m_progressBars; // Array is overhead if we have multiple progress bars to track scene vs total completion
     private Coroutine m_clipboardAutoHide;
 
+    public static event Action OnTaskHide;
+
     private void Awake()
     {
         m_taskTracker = FindFirstObjectByType<TaskTracker>();
@@ -177,5 +179,6 @@ public class UIManager : MonoBehaviour
 		ToggleUIVisibility(taskListAnim);
 		ToggleUIVisibility(CBAnimator);
         Time.timeScale = 1.0f;
+        OnTaskHide?.Invoke();
     }
 }


### PR DESCRIPTION
List of introductory tasks for the Slime level must be hidden in order to begin the tutorial
- Added an event to UIManager that fires when the introductory task list is closed
- Changed the tutorial's start function to instead fire from receiving this event
- Changed completion checks so that they only accrue progress when the tutorial is running

- [x]  I have run this branch locally
- [x]  I have performed a self-review of my code
- [x]  I have confirmed critical features still function